### PR TITLE
Fix compile errors

### DIFF
--- a/assets/forgetmenot/shaders/gbuffer/main.vert
+++ b/assets/forgetmenot/shaders/gbuffer/main.vert
@@ -1,5 +1,3 @@
-#include frex:shaders/api/vertex.glsl
-#include frex:shaders/api/material.glsl
 #include forgetmenot:shaders/lib/includes.glsl 
 
 void frx_pipelineVertex() {

--- a/assets/forgetmenot/shaders/post/frame_full.vert
+++ b/assets/forgetmenot/shaders/post/frame_full.vert
@@ -1,11 +1,6 @@
-#include frex:shaders/api/vertex.glsl
+#include forgetmenot:shaders/lib/includes.glsl
 
 uniform mat4 frxu_frameProjectionMatrix;
-uniform ivec2 frxu_size;
-uniform int frxu_lod;
-
-in vec2 in_uv;
-in vec4 in_vertex;
 
 out vec2 texcoord;
 


### PR DESCRIPTION
Fixes compile errors caused by redefinition/undeclared variables on vmware windows. Not sure if this is applicable for other platforms, but the errors are legitimate and it is probably better to fix it anyways.

Empty/all black skybox lods are still an issue