### PR TITLE
check if reprojected `hitPos` is out of buffer

### DIFF
--- a/assets/forgetmenot/shaders/post/fabulous/sort.frag
+++ b/assets/forgetmenot/shaders/post/fabulous/sort.frag
@@ -236,6 +236,14 @@ void main() {
 			// Reflection reprojection
 			vec3 hitPosScene = setupSceneSpacePos(hitPos);
 			hitPos = lastFrameSceneSpaceToScreenSpace(hitPosScene + frx_cameraPos - frx_lastCameraPos);
+			
+			// check if reprojected hitPos is out of buffer
+			if(
+				any(greaterThanEqual(hitPos.xy, ivec2(1.0))) ||
+				any(lessThan(hitPos.xy, ivec2(0.0)))
+			) {
+				hit = false;
+			}
 		}
 		
 		if(hit) {


### PR DESCRIPTION
fixes cases like this when rotating camera:
![2023-04-22_23 33 33](https://user-images.githubusercontent.com/8060034/233798764-89fb52f5-e5d5-4b0e-a77a-ef88be168a41.png)
