### PR TITLE
AMD moment

### DIFF
--- a/assets/forgetmenot/shaders/gbuffer/main.frag
+++ b/assets/forgetmenot/shaders/gbuffer/main.frag
@@ -13,8 +13,8 @@ uniform sampler2D u_glint;
 
 layout(location = 0) out vec4 fragColor;
 layout(location = 1) out vec4 fragNormal;
-layout(location = 2) out uvec3 fragData;
-layout(location = 3) out uvec3 fragData1;
+layout(location = 2) out uvec4 fragData;
+layout(location = 3) out uvec4 fragData1;
 
 bool isInventory;
 vec3 gamma;
@@ -257,7 +257,7 @@ void frx_pipelineFragment() {
 
 	fragColor = color;//vec4(frx_fragNormal * 0.5 + 0.5, 1.0);
 	fragNormal = vec4(frx_vertexNormal.xyz * 0.5 + 0.5, 1.0);
-	fragData = uvec3(packedX, packedY, packedZ);
+	fragData = uvec4(packedX, packedY, packedZ, 1u);
 	fragData1 = fragData;
 
 	gl_FragDepth = gl_FragCoord.z;


### PR DESCRIPTION
Before:
![2023-05-03_13 22 41](https://user-images.githubusercontent.com/8060034/235891393-b5d05a86-c218-45d7-8fdf-1a2652a08e9d.png)

After:
![2023-05-03_13 22 56](https://user-images.githubusercontent.com/8060034/235891419-51e0347d-ff7c-439c-8e29-b5d938f63581.png)
