### PR TITLE
simplify SSR traverser, complicate initial position adjustment

### DIFF
--- a/assets/forgetmenot/shaders/lib/inc/raytrace.glsl
+++ b/assets/forgetmenot/shaders/lib/inc/raytrace.glsl
@@ -5,59 +5,44 @@ Contains the raytracer from lomo, provided by fewizz.
 */
 
 bool raytrace(inout vec3 pos, vec3 dir, int steps, sampler2D depths, out float depth) {
-    const int power_of_two = 2;
-    const int last_level = 4;
+    const int last_level = 8;
+    const int level_step = 2;
 
-    vec2 dir_xy = dir.xy / length(dir.xy);
+    int level = 0;
 
-    int level = last_level;
+    while (
+        steps-- > 0
+        && all(lessThan(pos.xy, frxu_size))
+        && all(greaterThanEqual(pos.xy, vec2(0.0)))
+        && pos.z > 0.0
+    ) {
+        depth = texelFetch(depths, ivec2(pos.xy) >> level, level).r;
 
-    while (true) {
-        if (
-            steps <= 0
-                || any(greaterThanEqual(pos.xy, frxu_size))
-                || any(lessThan(pos.xy, vec2(0.0)))
-                || pos.z <= 0.0
-        ) {
-            return false;
+        vec3 advance; {
+            int cell_size = 1 << level; // 1, 4, 16, etc...
+            vec2 position_in_cell = mod(pos.xy * sign(dir.xy), cell_size);
+            vec2 dists_to_axis = cell_size - position_in_cell;
+            vec2 diagonal_dists = dists_to_axis / abs(dir.xy);
+            float dist = min(diagonal_dists.x, diagonal_dists.y);
+            advance = max(dist, 0.01) * 1.01 * dir;
         }
-        --steps;
 
-        while (true) {
-            depth = texelFetch(depths, ivec2(pos.xy) >> (level * power_of_two), level * power_of_two).r;
-            if (pos.z >= depth) {
-                if (level == 0) {
-                    return true;
-                }
-                --level;
+        if (pos.z + advance.z >= depth) {
+            pos += advance * max((depth - pos.z) / advance.z, 0.0); // go back
+            if (level > 0) {
+                level -= level_step;
             }
             else {
-                break;
-            }
-        }
-
-        vec3 advance;
-        {
-            int cell_size = 1 << (level * power_of_two); // 1, 4, 16, etc...
-            vec2 position_in_cell = mod(pos.xy * sign(dir_xy), cell_size);
-            vec2 dists_to_axis = cell_size - position_in_cell;
-            vec2 diagonal_dists = dists_to_axis / abs(dir_xy);
-            float dist_xy = max(min(diagonal_dists.x, diagonal_dists.y), 0.001) * 1.001;
-            advance = dist_xy * vec3(dir_xy, dir.z / length(dir.xy));
-        }
-
-        pos += advance;
-
-        if (pos.z >= depth) { // we hit the depth while advancing
-            pos.xy -= advance.xy * (pos.z - depth) / advance.z; // go back
-            pos.z = depth;
-            if (level == 0) {
                 return true;
             }
-            --level;
         }
         else {
-            level = last_level;
+            pos += advance;
+            if (level < last_level) {
+                level += level_step;
+            }
         }
     }
+
+    return false;
 }

--- a/assets/forgetmenot/shaders/post/fabulous/post_sort.frag
+++ b/assets/forgetmenot/shaders/post/fabulous/post_sort.frag
@@ -90,20 +90,34 @@ void reflections(
         screenSpacePos.z = min(screenSpacePos.z, prevFrameDepth);
 
         vec3 NDC = screenSpacePos * 2.0 - 1.0;
+
         vec4 D = frx_lastProjectionMatrix * vec4(viewReflectDir, 0.0);
-        vec3 windowSpaceDir = normalize(
-                (D.xyz - NDC.xyz * D.w) * vec3(frxu_size, 1.0)
-            );
+        vec3 windowSpaceDir = normalize((D.xyz - NDC.xyz * D.w) * vec3(frxu_size, 1.0));
         vec3 windowSpacePos = screenSpacePos * vec3(frxu_size, 1.0);
-        windowSpacePos.z -= max(0.0, windowSpaceDir.z * 4.0 * exp(material.roughness * 2.0));
-        windowSpacePos.z -= 1.0 / 1000000.0;
+
+        vec3 viewSpacePos = setupViewSpacePos(screenSpacePos);
+        vec3 viewSpaceNormal = mat3(frx_lastViewMatrix) * material.fragNormal;
+
+        // Calculating normal in window space, needed for initial position xy shift
+        vec3 shiftedByX = viewSpacePos + vec3(1.0, 0.0, -viewSpaceNormal.x/viewSpaceNormal.z) * 0.001;
+        vec3 shiftedByY = viewSpacePos + vec3(0.0, 1.0, -viewSpaceNormal.y/viewSpaceNormal.z) * 0.001;
+        shiftedByX = (viewSpaceToScreenSpace(shiftedByX) - screenSpacePos) * vec3(frxu_size, 1.0);
+        shiftedByY = (viewSpaceToScreenSpace(shiftedByY) - screenSpacePos) * vec3(frxu_size, 1.0);
+        vec3 windowSpaceNorm = cross(shiftedByY, shiftedByX) * sign(viewSpaceNormal.z);
+
+        windowSpacePos.z -= abs(windowSpaceDir.z) + 0.000001;
+        windowSpacePos.xy =
+            // center
+            floor(windowSpacePos.xy) + vec2(0.5) +
+            // closer to the pixel border, in direction of window space normal
+            (abs(windowSpaceNorm.x) > abs(windowSpaceNorm.y) ? vec2(sign(windowSpaceNorm.x), 0.0) : vec2(0.0, sign(windowSpaceNorm.y))) * 0.35;
 
         float hitDepth;
 
         bool hit = raytrace(
                 windowSpacePos,
                 windowSpaceDir,
-                40,
+                80,
                 hiDepthLevels,
                 hitDepth
             );


### PR DESCRIPTION
Fixes some precision issues, like these:
<img width="1920" height="1201" alt="2026-05-23_23 27 15" src="https://github.com/user-attachments/assets/400e512e-fe56-4049-a854-a39dc3f70691" />
<img width="1920" height="1201" alt="2026-05-23_23 27 28" src="https://github.com/user-attachments/assets/3736790e-e836-4097-88af-c8e45696f9d6" />

Also has less initial depth loss
Before
<img width="1920" height="1201" alt="2026-05-23_23 44 21" src="https://github.com/user-attachments/assets/8efd6963-de6a-45c4-b30a-06366f0b0a95" />
<img width="1825" height="962" alt="image" src="https://github.com/user-attachments/assets/2b60a7fd-add6-44bb-8740-4735d2f142b1" />


After
<img width="1920" height="1201" alt="2026-05-23_23 44 08" src="https://github.com/user-attachments/assets/b1cfc898-c926-43de-85f9-02a1ebc59d3a" />
<img width="1820" height="989" alt="image" src="https://github.com/user-attachments/assets/83f5d59e-8dc4-44b1-aa2d-ad2c806d603f" />

Perf is ~same